### PR TITLE
Update header style

### DIFF
--- a/wp-content/themes/twentytwentyfive/patterns/header.php
+++ b/wp-content/themes/twentytwentyfive/patterns/header.php
@@ -12,8 +12,8 @@
  */
 
 ?>
-<!-- wp:group {"align":"full","layout":{"type":"default"}} -->
-<div class="wp-block-group alignfull">
+<!-- wp:group {"align":"full","style":{"color":{"background":"#ffa500","text":"#ffffff"}},"layout":{"type":"default"}} -->
+<div class="wp-block-group alignfull has-text-color has-background" style="color:#ffffff;background-color:#ffa500">
 	<!-- wp:group {"layout":{"type":"constrained"}} -->
 	<div class="wp-block-group">
 		<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|30"}}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->


### PR DESCRIPTION
## Summary
- make the header background orange with white text

## Testing
- `php -l wp-content/themes/twentytwentyfive/patterns/header.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684b9c7de2188331ba668b3f0564e22e