### PR TITLE
Add sticky header style

### DIFF
--- a/wp-content/themes/twentytwentyfour/parts/header.html
+++ b/wp-content/themes/twentytwentyfour/parts/header.html
@@ -1,6 +1,6 @@
 <!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"20px","bottom":"20px"}}},"backgroundColor":"base","layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignwide has-base-background-color has-background"
-	style="padding-top:20px;padding-bottom:20px">
+<div class="wp-block-group alignwide site-header has-base-background-color has-background"
+       style="padding-top:20px;padding-bottom:20px">
 	<!-- wp:group {"align":"wide","layout":{"type":"flex","justifyContent":"space-between","flexWrap":"wrap"}} -->
 	<div class="wp-block-group alignwide">
 		<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20"},"layout":{"selfStretch":"fit","flexSize":null}},"layout":{"type":"flex"}} -->

--- a/wp-content/themes/twentytwentyfour/style.css
+++ b/wp-content/themes/twentytwentyfour/style.css
@@ -13,3 +13,10 @@ License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: twentytwentyfour
 Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, block-patterns, rtl-language-support, sticky-post, threaded-comments, translation-ready, wide-blocks, block-styles, style-variations, accessibility-ready, blog, portfolio, news
 */
+
+/* Sticky header */
+.site-header {
+    position: sticky;
+    top: 0;
+    z-index: 1000;
+}


### PR DESCRIPTION
## Summary
- add CSS rule for sticky header
- mark header element with `site-header` class

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_68590066f1bc8331a743f675c6d45eaf